### PR TITLE
Attributes that do not reduce the empirical risk

### DIFF
--- a/pyscm/scm/base.py
+++ b/pyscm/scm/base.py
@@ -166,7 +166,8 @@ class BaseSetCoveringMachine(object):
             if n_trn_errors < n_trn_errors_prev_iter:
                 n_trn_errors_prev_iter = n_trn_errors
             else:
-                self._verbose_print("The attribute does not reduce the training risk. Stopping here.")
+                self._verbose_print("The attribute does not reduce the training risk. It will not be added to the" + \
+                                    " model. Stopping here.")
                 break
 
             appended_attribute = self._add_attribute_to_model(binary_attributes[best_attribute_idx])


### PR DESCRIPTION
Sometimes, when iteratively adding attributes to the model, the best attribute does not reduce the number of training errors. For example, this can happen when a duplicate attribute is selected. This can also happen when the best attribute is selected only based on its cardinality (MetaSCM).

This has been fixed by computing the training error at each iteration and stopping if adding the attribute would not yield a training error smaller than the previous iteration's training error.
