### PR TITLE
Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.6
 
 addons:
   apt:

--- a/cpp_extensions/utility_python_bindings.cpp
+++ b/cpp_extensions/utility_python_bindings.cpp
@@ -7,7 +7,6 @@
 #include "best_utility.h"
 #include "solver.h"
 
-
 static PyObject *
 find_max(PyObject *self, PyObject *args){
     double p;
@@ -180,9 +179,28 @@ static PyMethodDef Methods[] = {
         {NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+
+static struct PyModuleDef _scm_utility_module = {
+    PyModuleDef_HEAD_INIT,
+    "_scm_utility",
+    NULL,
+    -1,
+    Methods
+};
+
+PyMODINIT_FUNC PyInit__scm_utility() {
+    import_array();
+    return PyModule_Create(&_scm_utility_module);
+};
+
+#else
+
 PyMODINIT_FUNC
 init_scm_utility
         (void){
     (void)Py_InitModule("_scm_utility", Methods);
     import_array();//necessary from numpy otherwise we crash with segfault
 }
+
+#endif

--- a/examples/training_time.py
+++ b/examples/training_time.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
 import logging
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,9 +29,9 @@ for p in np.linspace(0.01, 1.0, 10):
     took = time() - t
     times.append(took)
     nfs.append(nf)
-    print nf
-    print took
-    print
+    print(nf)
+    print(took)
+    print()
 
 plt.clf()
 plt.plot(nfs, times)

--- a/pyscm/deprecated/utils.py
+++ b/pyscm/deprecated/utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+from sklearn.externals.six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2014 Alexandre Drouin
@@ -54,7 +56,7 @@ def _class_to_string(instance):
     Private attributes must be marked with a leading underscore.
     """
     return instance.__class__.__name__ + "(" + ",".join(
-        [str(k) + "=" + str(v) for k, v in instance.__dict__.iteritems() if str(k[0]) != "_"]) + ")"
+        [str(k) + "=" + str(v) for k, v in itetitems(instance.__dict__) if str(k[0]) != "_"]) + ")"
 
 def _conditional_print(text, condition):
     """
@@ -69,7 +71,7 @@ def _conditional_print(text, condition):
         Print or do not print
     """
     if condition:
-        print text
+        print(text)
 
 def _split_into_contiguous(a_list):
     """

--- a/pyscm/deprecated/utils.py
+++ b/pyscm/deprecated/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
-from sklearn.externals.six import iteritems
+from six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2014 Alexandre Drouin

--- a/pyscm/model.py
+++ b/pyscm/model.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -17,6 +16,8 @@ from __future__ import print_function, division, absolute_import, unicode_litera
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 import numpy as np
 
 

--- a/pyscm/model.py
+++ b/pyscm/model.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin

--- a/pyscm/rules.py
+++ b/pyscm/rules.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -17,8 +16,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-import numpy as np
-
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .utils import _class_to_string
 

--- a/pyscm/rules.py
+++ b/pyscm/rules.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin

--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
-from sklearn.externals.six import iteritems
+from six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin

--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
-from six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -18,6 +16,9 @@ from six import iteritems
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+from __future__ import print_function, division, absolute_import, unicode_literals
+from six import iteritems
+
 import logging
 import numpy as np
 

--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from sklearn.externals.six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -50,7 +52,7 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
                 "random_state": self.random_state}
 
     def set_params(self, **parameters):
-        for parameter, value in parameters.items():
+        for parameter, value in iteritems(parameters):
             self.setattr(parameter, value)
         return self
 
@@ -66,7 +68,7 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
         logging.debug("Parsing additional fit parameters")
         utility_function_additional_args = {}
         if fit_params is not None:
-            for key, value in fit_params.iteritems():
+            for key, value in iteritems(fit_params):
                 if key[:9] == "utility__":
                     utility_function_additional_args[key[9:]] = value
 

--- a/pyscm/utils.py
+++ b/pyscm/utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
-from six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -18,6 +16,9 @@ from six import iteritems
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from six import iteritems
 
 
 def _class_to_string(instance):

--- a/pyscm/utils.py
+++ b/pyscm/utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from sklearn.externals.six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin
@@ -37,4 +39,4 @@ def _class_to_string(instance):
     Private attributes must be marked with a leading underscore.
     """
     return instance.__class__.__name__ + "(" + ",".join(
-        [str(k) + "=" + str(v) for k, v in instance.__dict__.iteritems() if str(k[0]) != "_"]) + ")"
+        [str(k) + "=" + str(v) for k, v in iteritems(instance.__dict__) if str(k[0]) != "_"]) + ")"

--- a/pyscm/utils.py
+++ b/pyscm/utils.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
-from sklearn.externals.six import iteritems
+from six import iteritems
 """
     pyscm -- The Set Covering Machine in Python
     Copyright (C) 2017 Alexandre Drouin

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 """
 from numpy import get_include as get_numpy_include
 from platform import system as get_os_name
-
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
@@ -57,8 +56,8 @@ setup(
     packages=find_packages(),
 
     cmdclass={'build_ext': build_ext},
-    setup_requires=["numpy", "scipy", "scikit-learn"],
-    install_requires=["numpy", "scipy", "scikit-learn"],
+    setup_requires=["numpy", "scipy", "scikit-learn", "six"],
+    install_requires=["numpy", "scipy", "scikit-learn", "six"],
 
     author="Alexandre Drouin",
     author_email="aldro61@gmail.com",


### PR DESCRIPTION
Fixed last comments. Imports for iteritems are directly from six.
Example training_times was made compatible py2 and py3