### PR TITLE
Fixed solver memory leaks

### DIFF
--- a/cpp_extensions/best_utility.h
+++ b/cpp_extensions/best_utility.h
@@ -24,6 +24,12 @@ public:
         this->best_n_equiv = 0;
         this->resize(memory_size);
     }
+    
+    ~BestUtility(){
+        delete [] this->best_feat_idx;
+        delete [] this->best_feat_threshold;
+        delete [] this->best_feat_kind;
+    }
 
     inline void add_equivalent(long const &feature_idx, double const &threshold, uint8_t const &kind);
     inline void clear();

--- a/cpp_extensions/solver.cpp
+++ b/cpp_extensions/solver.cpp
@@ -115,5 +115,6 @@ int find_max(double p,
         update_optimal_solution(out_best_solution, i, prev_threshold, N, P_bar, p, feature_weights[i],
                                 n_negative, n_positive);
     }
+    delete [] example_is_included;
     return 0;
 }


### PR DESCRIPTION
### Memory previously not released : ###

- bool array example_is_included
- BestUtility arrays (idx, threshold & kind)