### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/decision_boundary.py
+++ b/examples/decision_boundary.py
@@ -112,7 +112,7 @@ for ds_cnt, ds in enumerate(datasets):
         ax.set_yticks(())
         if ds_cnt == 0:
             ax.set_title(name)
-        ax.text(xx.max() - .3, yy.min() + .3, ('%.2f' % score).lstrip('0'),
+        ax.text(xx.max() - .3, yy.min() + .3, ('{0:.2f}'.format(score)).lstrip('0'),
                 size=15, horizontalalignment='right')
         i += 1
 

--- a/examples/training_time.py
+++ b/examples/training_time.py
@@ -34,7 +34,7 @@ def increase_n_features():
     plt.plot(nfs, avg_times)
     plt.xlabel("n features")
     plt.ylabel("time (seconds)")
-    plt.title("Training time for %d <= n <= %d features (%d examples)" % (min(nfs), max(nfs), n_examples))
+    plt.title("Training time for {0:d} <= n <= {1:d} features ({2:d} examples)".format(min(nfs), max(nfs), n_examples))
     plt.savefig("n_features.png", bbox_inches="tight")
 
 
@@ -62,7 +62,7 @@ def increase_n_examples():
     plt.plot(n_exs, avg_times)
     plt.xlabel("n examples")
     plt.ylabel("time (seconds)")
-    plt.title("Training time for %d <= n <= %d examples (%d features)" % (min(n_exs), max(n_exs), n_features))
+    plt.title("Training time for {0:d} <= n <= {1:d} examples ({2:d} features)".format(min(n_exs), max(n_exs), n_features))
     plt.savefig("n_examples.png", bbox_inches="tight")
 
 

--- a/pyscm/rules.py
+++ b/pyscm/rules.py
@@ -120,4 +120,4 @@ class DecisionStump(BaseRule):
                              kind="greater" if self.kind == "less_equal" else "less_equal")
 
     def __str__(self):
-        return "X[%d] %s %.3f" % (self.feature_idx, ">" if self.kind == "greater" else "<=", self.threshold)
+        return "X[{0:d}] {1!s} {2:.3f}".format(self.feature_idx, ">" if self.kind == "greater" else "<=", self.threshold)

--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -98,8 +98,7 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
         self.classes_, y, total_n_ex_by_class = np.unique(y, return_inverse=True, return_counts=True)
         if len(self.classes_) != 2:
             raise ValueError("y must contain two unique classes.")
-        logging.debug("The data contains %d examples. Negative class is %s (n: %d) and positive class is %s (n: %d)." %
-                      (len(y), self.classes_[0], total_n_ex_by_class[0], self.classes_[1], total_n_ex_by_class[1]))
+        logging.debug("The data contains {0:d} examples. Negative class is {1!s} (n: {2:d}) and positive class is {3!s} (n: {4:d}).".format(len(y), self.classes_[0], total_n_ex_by_class[0], self.classes_[1], total_n_ex_by_class[1]))
 
         # Invert the classes if we are learning a disjunction
         logging.debug("Preprocessing example labels")
@@ -128,18 +127,18 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
                                                      **utility_function_additional_args)
 
             # TODO: Support user specified tiebreaker
-            logging.debug("Tiebreaking. Found %d optimal rules" % len(opti_feat_idx))
+            logging.debug("Tiebreaking. Found {0:d} optimal rules".format(len(opti_feat_idx)))
             keep_idx = random_state.randint(0, len(opti_feat_idx))
             stump = DecisionStump(feature_idx=opti_feat_idx[keep_idx], threshold=opti_threshold[keep_idx],
                                   kind="greater" if opti_kind[keep_idx] == 0 else "less_equal")
 
-            logging.debug("The best rule has utility %.3f" % opti_utility)
+            logging.debug("The best rule has utility {0:.3f}".format(opti_utility))
             self._add_attribute_to_model(stump)
 
             logging.debug("Discarding all examples that the rule classifies as negative")
             remaining_example_idx = remaining_example_idx[stump.classify(X[remaining_example_idx])]
             remaining_negative_example_idx = remaining_negative_example_idx[stump.classify(X[remaining_negative_example_idx])]
-            logging.debug("There are %d examples remaining (%d negatives)" % (len(remaining_example_idx),
+            logging.debug("There are {0:d} examples remaining ({1:d} negatives)".format(len(remaining_example_idx),
                                                                               len(remaining_negative_example_idx)))
 
             iteration_callback(self.model_)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:aldro61:pyscm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:aldro61:pyscm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)