### PR TITLE
fix a memory conflict

### DIFF
--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -134,7 +134,7 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
             opti_threshold, \
             opti_kind, \
             opti_N, \
-            opti_P_bar = self._get_best_utility_rules(X, y, X_argsort_by_feature_T, remaining_example_idx.copy(),
+            opti_P_bar = self._get_best_utility_rules(X.copy(), y.copy(), X_argsort_by_feature_T.copy(), remaining_example_idx.copy(),
                                                       **utility_function_additional_args)
 
             logging.debug("Tiebreaking. Found {0:d} optimal rules".format(len(opti_feat_idx)))


### PR DESCRIPTION
There was a memory conflict while initializing and fitting several scm classifiers in the same code. For instance while using scikit-learn BaggingClassifier() with a SCM as classifier. 
Values of arguments where changed after calling self._get_best_utility_rules() in pyscm/scm.py line 137.
This is fix by passing copies of parameters in the call to self._get_best_utility_rules().