### PR TITLE
Fix repeated rules with 0 utility

### DIFF
--- a/pyscm/scm.py
+++ b/pyscm/scm.py
@@ -148,13 +148,15 @@ class BaseSetCoveringMachine(BaseEstimator, ClassifierMixin):
             if self.model_type == "conjunction"
             else DisjunctionModel()
         )
+        # Dummy value to ensure we enter loop.
+        opti_utility = 1
 
         logging.debug("Training start")
         remaining_example_idx = np.arange(len(y))
         remaining_negative_example_idx = neg_ex_idx
         while (
             len(remaining_negative_example_idx) > 0
-            and len(self.model_) < self.max_rules
+            and len(self.model_) < self.max_rules and opti_utility > 0
         ):
             logging.debug("Finding the optimal rule to add to the model")
             (


### PR DESCRIPTION
0 utility rules could get repeated until model had `self.max_rules` rules if it couldn't classify all the negative examples correctly. I think the original paper supposed the task is realizable / separable and so it makes sense to implement it the way it was prior to this patch. However, real life scenarios are, as you know, rarely so easy, hence the PR.

Tested with Python 3.7.17

All checks passed:
```running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing pyscm_ml.egg-info/PKG-INFO
writing dependency_links to pyscm_ml.egg-info/dependency_links.txt
writing requirements to pyscm_ml.egg-info/requires.txt
writing top-level names to pyscm_ml.egg-info/top_level.txt
reading manifest file 'pyscm_ml.egg-info/SOURCES.txt'
writing manifest file 'pyscm_ml.egg-info/SOURCES.txt'
running build_ext
copying build/lib.linux-x86_64-3.7/pyscm/_scm_utility.cpython-37m-x86_64-linux-gnu.so -> pyscm
test_sklearn_grid_search (pyscm.tests.test_sklearn_compatibility.SklearnCompatibilityTests)
Test compatibility with sklearn GridSearchCV function ... ok
test_sklearn_pipeline (pyscm.tests.test_sklearn_compatibility.SklearnCompatibilityTests)
Test compatibility with sklearn pipelines ... ok
test_1 (pyscm.tests.test_utility.UtilityTests)
Dummy test #1 ... ok
test_2 (pyscm.tests.test_utility.UtilityTests)
Test that hyperparameter p works ... ok
test_3 (pyscm.tests.test_utility.UtilityTests)
Test that feature_weights works ... ok
test_4 (pyscm.tests.test_utility.UtilityTests)
Test that example_idx works ... ok
test_5 (pyscm.tests.test_utility.UtilityTests)
Test that solver return accurate equivalent rules ... ok
test_6 (pyscm.tests.test_utility.UtilityTests)
Test that solver return accurate N and P_bar ... ok
test_random_data (pyscm.tests.test_utility.UtilityTests)
Random testing ... ok

----------------------------------------------------------------------
Ran 9 tests in 1.714s

OK
```

As a side-note, I tried testing this patch with Python 3.11.3 but the `nose` library had issues with `collections` having migrated `Callable` to `abc.Callable`. This is only an issue for the test suite, PySCM otherwise runs fine on Python 3.11.3.