### PR TITLE
Fix installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include cpp_extensions/*

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ Marchand, M., & Taylor, J. S. (2003). The set covering machine. Journal of Machi
 ``` 
 pip install pyscm-ml
 ```
-or
+or locally with
 
 ``` 
-python setup.py install
+python -m pip install -e .
 ```
 
 ## Running tests
 ```
-python setup.py test
+python -m pip install pytest
+python -m pytest
 ```
 
 ## Contributors

--- a/makefile
+++ b/makefile
@@ -1,7 +1,6 @@
 package: .dev-dependencies
-	rm -r ./dist ./build
-	python setup.py sdist
-	python setup.py bdist_wheel
+	rm -r ./dist || true
+	python -m build
 
 upload-pypi: .dev-dependencies
 	twine upload --skip-existing dist/* --verbose
@@ -10,4 +9,4 @@ upload-testpypi: .dev-dependencies
 	twine upload --skip-existing  --repository testpypi dist/* --verbose
 
 .dev-dependencies:
-	pip install wheel twine
+	pip install build twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy<2"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy<2
 scikit-learn
 six

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-from numpy import get_include as get_numpy_include
+import numpy
 from platform import system as get_os_name
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext as _build_ext
@@ -28,25 +28,15 @@ else:
     os_compile_flags = []
 
 
-# Required for the automatic installation of numpy
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-
-        self.include_dirs.append(numpy.get_include())
-
-
 solver_module = Extension(
     "pyscm._scm_utility",
     language="c++",
     sources=["cpp_extensions/utility_python_bindings.cpp", "cpp_extensions/solver.cpp"],
     extra_compile_args=["-std=c++0x"] + os_compile_flags,
+    include_dirs=[numpy.get_include()]
 )
 
-dependencies = ["numpy", "scipy", "scikit-learn", "six"]
+dependencies = ["numpy<2", "scikit-learn", "six"]
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -55,8 +45,6 @@ setup(
     name="pyscm-ml",
     version="1.1.1",
     packages=find_packages(),
-    cmdclass={"build_ext": build_ext},
-    setup_requires=dependencies,
     install_requires=dependencies,
     author="Alexandre Drouin",
     author_email="aldro61@gmail.com",
@@ -77,6 +65,4 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     ext_modules=[solver_module],
-    test_suite="nose.collector",
-    tests_require=["nose"],
 )


### PR DESCRIPTION
As mention in issue https://github.com/aldro61/pyscm/issues/58, the package can no longer be installed locally or from PyPI (pyscm-ml).

This pull request is a minimal modification to enable the package to be installed. Specifically :
- Because of NumPy v2 C-API breaking changes (see [here](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#c-api-changes)), numpy dependency is set to `numpy<2` (as a build dependancy and a package dependancy).
- The addition of a minimal `pyproject.toml` will provide access to the NumPy C-API, hence `import numpy` should now work as expected when `setup.py` is called.
- The file `MANIFEST.in` will tell `setuptools` to add files in `cpp_extensions/` when building the project.
- `test_suite` and `test_require` are no longer recognized by `setup(...)` (see [here](https://setuptools.pypa.io/en/latest/deprecated/distutils/apiref.html#module-distutils.core)).
- Changes were made to the `makefile` accordingly.
- Update installation instructions in the README.md

I was able to run all files in `examples/` using this build.

Thank you for your time in reviewing this work.